### PR TITLE
Frustum-Sphere intersection

### DIFF
--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -60,6 +60,7 @@ set(ENGINE_SRCS
     GameObject/SuperGameObject.cpp
     Physics/AxisAlignedBoundingBox.cpp
     Physics/Frustum.cpp
+    Physics/Sphere.cpp
     Profiling/ProfilingManager.cpp
     Profiling/CPUProfiling.cpp
     Profiling/GPUProfiling.cpp
@@ -130,6 +131,7 @@ set(ENGINE_HEADERS
     GameObject/SuperGameObject.hpp
     Physics/AxisAlignedBoundingBox.hpp
     Physics/Frustum.hpp
+    Physics/Sphere.hpp
     Profiling/ProfilingManager.hpp
     Profiling/CPUProfiling.hpp
     Profiling/GPUProfiling.hpp

--- a/src/Engine/Lighting/DeferredLighting.cpp
+++ b/src/Engine/Lighting/DeferredLighting.cpp
@@ -18,6 +18,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include "../Physics/AxisAlignedBoundingBox.hpp"
+#include "../Physics/Sphere.hpp"
 #include "../Physics/Frustum.hpp"
 #include "../System/DebugDrawingSystem.hpp"
 
@@ -191,7 +192,7 @@ void DeferredLighting::Render(Scene& scene, Entity* camera, const glm::vec2& scr
     }
     
     // At which point lights should be cut off (no longer contribute).
-    const double cutOff = 0.001;
+    const double cutOff = 0.002;
     
     // Render all spot lights.
     std::vector<Component::SpotLight*>& spotLights = scene.GetAll<Component::SpotLight>();
@@ -213,7 +214,7 @@ void DeferredLighting::Render(Scene& scene, Entity* camera, const glm::vec2& scr
         }
     }
     
-    Physics::AxisAlignedBoundingBox aabb(glm::vec3(1.f, 1.f, 1.f), glm::vec3(0.f, 0.f, 0.f), glm::vec3(-0.5f, -0.5f, -0.5f), glm::vec3(0.5f, 0.5f, 0.5f));
+    Physics::Frustum frustum(viewProjectionMat);
     
     // Render all point lights.
     std::vector<Component::PointLight*>& pointLights = scene.GetAll<Component::PointLight>();
@@ -222,10 +223,9 @@ void DeferredLighting::Render(Scene& scene, Entity* camera, const glm::vec2& scr
         Component::Transform* transform = lightEntity->GetComponent<Component::Transform>();
         if (transform != nullptr) {
             float scale = sqrt((1.0 / cutOff - 1.0) / light->attenuation * light->intensity);
-            glm::mat4 modelMat = glm::translate(glm::mat4(), transform->GetWorldPosition()) * glm::scale(glm::mat4(), glm::vec3(1.f, 1.f, 1.f) * scale);
+            Physics::Sphere sphere(transform->GetWorldPosition(), scale);
             
-            Physics::Frustum frustum(viewProjectionMat * modelMat);
-            if (frustum.Collide(aabb)) {
+            if (frustum.Collide(sphere)) {
                 glm::vec4 position = glm::vec4(glm::vec3(transform->modelMatrix[3][0], transform->modelMatrix[3][1], transform->modelMatrix[3][2]), 1.0);
                 mLights[lightIndex].position = viewMat * position;
                 mLights[lightIndex].intensities = light->color * light->intensity;

--- a/src/Engine/Physics/Frustum.cpp
+++ b/src/Engine/Physics/Frustum.cpp
@@ -6,40 +6,28 @@
 namespace Physics {
     Frustum::Frustum(const glm::mat4& matrix) {
         // Left clipping plane
-        mPlanes[0].x = glm::row(matrix, 3).x + glm::row(matrix, 0).x;
-        mPlanes[0].y = glm::row(matrix, 3).y + glm::row(matrix, 0).y;
-        mPlanes[0].z = glm::row(matrix, 3).z + glm::row(matrix, 0).z;
-        mPlanes[0].w = glm::row(matrix, 3).w + glm::row(matrix, 0).w;
+        mPlanes[0] = glm::row(matrix, 3) + glm::row(matrix, 0);
+        mPlanes[0] /= glm::length(glm::vec3(mPlanes[0]));
     
         // Right clipping plane
-        mPlanes[1].x = glm::row(matrix, 3).x - glm::row(matrix, 0).x;
-        mPlanes[1].y = glm::row(matrix, 3).y - glm::row(matrix, 0).y;
-        mPlanes[1].z = glm::row(matrix, 3).z - glm::row(matrix, 0).z;
-        mPlanes[1].w = glm::row(matrix, 3).w - glm::row(matrix, 0).w;
+        mPlanes[1] = glm::row(matrix, 3) - glm::row(matrix, 0);
+        mPlanes[1] /= glm::length(glm::vec3(mPlanes[1]));
     
         // Top clipping plane
-        mPlanes[2].x = glm::row(matrix, 3).x - glm::row(matrix, 1).x;
-        mPlanes[2].y = glm::row(matrix, 3).y - glm::row(matrix, 1).y;
-        mPlanes[2].z = glm::row(matrix, 3).z - glm::row(matrix, 1).z;
-        mPlanes[2].w = glm::row(matrix, 3).w - glm::row(matrix, 1).w;
+        mPlanes[2] = glm::row(matrix, 3) - glm::row(matrix, 1);
+        mPlanes[2] /= glm::length(glm::vec3(mPlanes[2]));
     
         // Bottom clipping plane
-        mPlanes[3].x = glm::row(matrix, 3).x + glm::row(matrix, 1).x;
-        mPlanes[3].y = glm::row(matrix, 3).y + glm::row(matrix, 1).y;
-        mPlanes[3].z = glm::row(matrix, 3).z + glm::row(matrix, 1).z;
-        mPlanes[3].w = glm::row(matrix, 3).w + glm::row(matrix, 1).w;
+        mPlanes[3] = glm::row(matrix, 3) + glm::row(matrix, 1);
+        mPlanes[3] /= glm::length(glm::vec3(mPlanes[3]));
     
         // Near clipping plane
-        mPlanes[4].x = glm::row(matrix, 3).x + glm::row(matrix, 2).x;
-        mPlanes[4].y = glm::row(matrix, 3).y + glm::row(matrix, 2).y;
-        mPlanes[4].z = glm::row(matrix, 3).z + glm::row(matrix, 2).z;
-        mPlanes[4].w = glm::row(matrix, 3).w + glm::row(matrix, 2).w;
+        mPlanes[4] = glm::row(matrix, 3) + glm::row(matrix, 2);
+        mPlanes[4] /= glm::length(glm::vec3(mPlanes[4]));
     
         // Far clipping plane
-        mPlanes[5].x = glm::row(matrix, 3).x - glm::row(matrix, 2).x;
-        mPlanes[5].y = glm::row(matrix, 3).y - glm::row(matrix, 2).y;
-        mPlanes[5].z = glm::row(matrix, 3).z - glm::row(matrix, 2).z;
-        mPlanes[5].w = glm::row(matrix, 3).w - glm::row(matrix, 2).w;
+        mPlanes[5] = glm::row(matrix, 3) - glm::row(matrix, 2);
+        mPlanes[5] /= glm::length(glm::vec3(mPlanes[5]));
     }
     
     bool Frustum::Collide(const AxisAlignedBoundingBox& aabb) const {

--- a/src/Engine/Physics/Frustum.cpp
+++ b/src/Engine/Physics/Frustum.cpp
@@ -1,6 +1,7 @@
 #include "Frustum.hpp"
 
 #include "AxisAlignedBoundingBox.hpp"
+#include "Sphere.hpp"
 #include <glm/gtc/matrix_access.hpp>
 
 namespace Physics {
@@ -56,6 +57,16 @@ namespace Physics {
             if (!inside)
                 return false;
         }
+        return true;
+    }
+    
+    bool Frustum::Collide(const Sphere& sphere) const {
+        // Check the signed distance between the sphere and the frustum planes.
+        for (int plane = 0; plane < 6; ++plane) {
+            if (DistanceToPoint(mPlanes[plane], sphere.position) < -sphere.radius)
+                return false;
+        }
+        
         return true;
     }
     

--- a/src/Engine/Physics/Frustum.hpp
+++ b/src/Engine/Physics/Frustum.hpp
@@ -4,6 +4,7 @@
 
 namespace Physics {
     class AxisAlignedBoundingBox;
+    class Sphere;
     
     /// A viewing frustum.
     /**
@@ -23,6 +24,13 @@ namespace Physics {
              * @return Whether there was a collision
              */
             bool Collide(const AxisAlignedBoundingBox& aabb) const;
+            
+            /// Check collision between frustum and a sphere.
+            /**
+             * @param sphere The sphere to check collision against.
+             * @return Whether there was a collision
+             */
+            bool Collide(const Sphere& sphere) const;
     
         private:
             glm::vec4 mPlanes[6];

--- a/src/Engine/Physics/Sphere.cpp
+++ b/src/Engine/Physics/Sphere.cpp
@@ -1,0 +1,8 @@
+#include "Sphere.hpp"
+
+namespace Physics {
+    Sphere::Sphere(const glm::vec3& position, float radius) {
+        this->position = position;
+        this->radius = radius;
+    }
+}

--- a/src/Engine/Physics/Sphere.hpp
+++ b/src/Engine/Physics/Sphere.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace Physics {
+    /// A sphere.
+    /**
+     * Used for intersection testing.
+     */
+    class Sphere {
+        public:
+            /// Origin.
+            glm::vec3 position;
+            
+            /// Radius.
+            float radius;
+            
+            /// Create new sphere.
+            /**
+             * @param position The origin of the sphere.
+             * @param radius The radius of the sphere.
+             */
+            Sphere(const glm::vec3& position, float radius);
+    };
+}


### PR DESCRIPTION
Use spheres rather than axis-aligned bounding boxes when frustum culling lights.